### PR TITLE
configpanel: catch FileNotFoundException

### DIFF
--- a/configpanel/src/com/cyanogenmod/settings/device/Startup.java
+++ b/configpanel/src/com/cyanogenmod/settings/device/Startup.java
@@ -34,6 +34,7 @@ import android.os.SystemClock;
 import android.os.UserHandle;
 import android.preference.PreferenceManager;
 import android.service.gesture.IGestureService;
+import android.util.Log;
 import android.view.InputDevice;
 import android.view.InputEvent;
 import android.view.KeyCharacterMap;
@@ -45,6 +46,9 @@ import com.cyanogenmod.settings.device.utils.Constants;
 import com.cyanogenmod.settings.device.utils.FileUtils;
 
 public class Startup extends BroadcastReceiver {
+
+    private static final String TAG = Startup.class.getSimpleName();
+
     @Override
     public void onReceive(final Context context, final Intent intent) {
         if (intent.getAction().equals(Intent.ACTION_BOOT_COMPLETED)) {
@@ -58,7 +62,10 @@ public class Startup extends BroadcastReceiver {
                     boolean defaultValue = Constants.sNodeDefaultMap.get(pref);
                     boolean value = Constants.isPreferenceEnabled(context, pref, defaultValue);
                     String node = Constants.sNodePreferenceMap.get(pref);
-                    FileUtils.writeLine(node, value ? "1" : "0");
+                    if (!FileUtils.writeLine(node, value ? "1" : "0")) {
+                        Log.w(TAG, "Write to node " + node +
+                            " failed while restoring saved preference values");
+                    }
                 }
             }
 

--- a/configpanel/src/com/cyanogenmod/settings/device/utils/FileUtils.java
+++ b/configpanel/src/com/cyanogenmod/settings/device/utils/FileUtils.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.FileNotFoundException;
 
 public final class FileUtils {
     private static final String TAG = "FileUtils";
@@ -66,6 +67,9 @@ public final class FileUtils {
             fos.write(value.getBytes());
             fos.flush();
             fos.close();
+        } catch (FileNotFoundException e) {
+            Log.w(TAG, "No such file " + fileName + " for writing", e);
+            return false;
         } catch (IOException e) {
             Log.e(TAG, "Could not write to file " + fileName, e);
             return false;


### PR DESCRIPTION
There is no /proc/touchpad/enable node in oneplusone, it is used by N1.
It causes the following exception on startup when Startup.java
tries to restore the values to default.
Catching that exception insteads in FileUtils.java.

This fixes:
E FileUtils: Could not write to file /proc/touchpad/enable
E FileUtils: java.io.FileNotFoundException: /proc/touchpad/enable: open failed: ENOENT (No such file or directory)
E FileUtils:    at libcore.io.IoBridge.open(IoBridge.java:452)
E FileUtils:    at java.io.FileOutputStream.<init>(FileOutputStream.java:87)
E FileUtils:    at java.io.FileOutputStream.<init>(FileOutputStream.java:127)
E FileUtils:    at java.io.FileOutputStream.<init>(FileOutputStream.java:116)
E FileUtils:    at com.cyanogenmod.settings.device.utils.FileUtils.writeLine(FileUtils.java:65)
E FileUtils:    at com.cyanogenmod.settings.device.Startup.onReceive(Startup.java:61)
E FileUtils:    at android.app.ActivityThread.handleReceiver(ActivityThread.java:2769)
E FileUtils:    at android.app.ActivityThread.-wrap14(ActivityThread.java)
E FileUtils:    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1440)
E FileUtils:    at android.os.Handler.dispatchMessage(Handler.java:102)
E FileUtils:    at android.os.Looper.loop(Looper.java:148)
E FileUtils:    at android.app.ActivityThread.main(ActivityThread.java:5466)
E FileUtils:    at java.lang.reflect.Method.invoke(Native Method)
E FileUtils:    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
E FileUtils:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
E FileUtils: Caused by: android.system.ErrnoException: open failed: ENOENT (No such file or directory)
E FileUtils:    at libcore.io.Posix.open(Native Method)
E FileUtils:    at libcore.io.BlockGuardOs.open(BlockGuardOs.java:186)
E FileUtils:    at libcore.io.IoBridge.open(IoBridge.java:438)
E FileUtils:    ... 14 more

Change-Id: I50daf381f0551e3fd37c1570e01ae5914bfcce86
