### PR TITLE
Lazily initialize the rear camera ID.

### DIFF
--- a/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
+++ b/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
@@ -124,21 +124,6 @@ public class KeyHandler implements DeviceKeyHandler {
 
         mCameraManager = (CameraManager) mContext.getSystemService(Context.CAMERA_SERVICE);
         mCameraManager.registerTorchCallback(new MyTorchCallback(), mEventHandler);
-
-        // Get first rear camera id
-        try {
-            for (final String cameraId : mCameraManager.getCameraIdList()) {
-                CameraCharacteristics characteristics =
-                        mCameraManager.getCameraCharacteristics(cameraId);
-                int cOrientation = characteristics.get(CameraCharacteristics.LENS_FACING);
-                if (cOrientation == CameraCharacteristics.LENS_FACING_BACK) {
-                    mRearCameraId = cameraId;
-                    break;
-                }
-            }
-        } catch (CameraAccessException e) {
-            // Ignore
-        }
     }
 
     private class MyTorchCallback extends CameraManager.TorchCallback {
@@ -155,6 +140,25 @@ public class KeyHandler implements DeviceKeyHandler {
                 return;
             mTorchEnabled = false;
         }
+    }
+
+    private String getRearCameraId() {
+        if (mRearCameraId == null) {
+            try {
+                for (final String cameraId : mCameraManager.getCameraIdList()) {
+                    CameraCharacteristics characteristics =
+                            mCameraManager.getCameraCharacteristics(cameraId);
+                    int cOrientation = characteristics.get(CameraCharacteristics.LENS_FACING);
+                    if (cOrientation == CameraCharacteristics.LENS_FACING_BACK) {
+                        mRearCameraId = cameraId;
+                        break;
+                    }
+                }
+            } catch (CameraAccessException e) {
+                // Ignore
+            }
+        }
+        return mRearCameraId;
     }
 
     private void ensureKeyguardManager() {
@@ -189,11 +193,12 @@ public class KeyHandler implements DeviceKeyHandler {
                 dispatchMediaKeyWithWakeLockToMediaSession(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE);
                 doHapticFeedback();
                 break;
-            case GESTURE_V_SCANCODE:
-                if (mRearCameraId != null) {
+            case GESTURE_V_SCANCODE: {
+                String rearCameraId = getRearCameraId();
+                if (rearCameraId != null) {
                     mGestureWakeLock.acquire(GESTURE_WAKELOCK_DURATION);
                     try {
-                        mCameraManager.setTorchMode(mRearCameraId, !mTorchEnabled);
+                        mCameraManager.setTorchMode(rearCameraId, !mTorchEnabled);
                         mTorchEnabled = !mTorchEnabled;
                     } catch (CameraAccessException e) {
                         // Ignore
@@ -201,6 +206,7 @@ public class KeyHandler implements DeviceKeyHandler {
                     doHapticFeedback();
                 }
                 break;
+            }
             case GESTURE_LTR_SCANCODE:
                 dispatchMediaKeyWithWakeLockToMediaSession(KeyEvent.KEYCODE_MEDIA_PREVIOUS);
                 doHapticFeedback();


### PR DESCRIPTION
At the time the key handler is constructed, the camera manager may not
be up yet. Initializing the camera ID in that scenario means never
getting a valid ID, thus the flashlight gesture will be broken.

Change-Id: Ic09136e92ae11927784c5d382dfa10ac68ec2c4b
